### PR TITLE
Remove idp url from oauth defaults to avoid exposing it to the world

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
     ```elixir
     config :ueberauth, Ueberauth.Strategy.Amco.OAuth,
+      site: System.get_env("AMCO_IDP_URL"),
       client_id: System.get_env("AMCO_CLIENT_ID"),
       client_secret: System.get_env("AMCO_CLIENT_SECRET")
     ```
@@ -41,6 +42,7 @@
 
     ```elixir
     config :ueberauth, Ueberauth.Strategy.Amco.OAuth,
+      site: {System, :get_env, ["AMCO_IDP_URL"]},
       client_id: {System, :get_env, ["AMCO_CLIENT_ID"]},
       client_secret: {System, :get_env, ["AMCO_CLIENT_SECRET"]}
     ```

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@
 
 4.  Update your provider configuration:
 
-    Use that if you want to read client ID/secret from the environment
-    variables in the compile time:
+    Example 1: Using environment variables at compile time:
 
     ```elixir
     config :ueberauth, Ueberauth.Strategy.Amco.OAuth,
@@ -37,14 +36,22 @@
       client_secret: System.get_env("AMCO_CLIENT_SECRET")
     ```
 
-    Use that if you want to read client ID/secret from the environment
-    variables in the run time:
+    Example 2: Using environment variables from a runtime file:
 
     ```elixir
     config :ueberauth, Ueberauth.Strategy.Amco.OAuth,
       site: {System, :get_env, ["AMCO_IDP_URL"]},
       client_id: {System, :get_env, ["AMCO_CLIENT_ID"]},
       client_secret: {System, :get_env, ["AMCO_CLIENT_SECRET"]}
+    ```
+
+    Example 3: Using strings in a managed file at runtime:
+
+    ```elixir
+    config :ueberauth, Ueberauth.Strategy.Amco.OAuth,
+      site: "https://my_idp.example.com",
+      client_id: "my client id",
+      client_secret: "my client secret"
     ```
 
 5.  Include the Überauth plug in your controller:

--- a/lib/ueberauth/strategy/amco/exceptions.ex
+++ b/lib/ueberauth/strategy/amco/exceptions.ex
@@ -5,3 +5,7 @@ end
 defmodule Ueberauth.Strategy.Amco.Exceptions.EmptyAccessTokenSource do
   defexception message: "access_token_source option is required"
 end
+
+defmodule Ueberauth.Strategy.Amco.Exceptions.MissingSiteConfiguration do
+  defexception message: "site configuration option is missed"
+end

--- a/lib/ueberauth/strategy/amco/exceptions.ex
+++ b/lib/ueberauth/strategy/amco/exceptions.ex
@@ -7,5 +7,5 @@ defmodule Ueberauth.Strategy.Amco.Exceptions.EmptyAccessTokenSource do
 end
 
 defmodule Ueberauth.Strategy.Amco.Exceptions.MissingSiteConfiguration do
-  defexception message: "Configuration option 'site' is missed"
+  defexception message: "Configuration option 'site' is missing"
 end

--- a/lib/ueberauth/strategy/amco/exceptions.ex
+++ b/lib/ueberauth/strategy/amco/exceptions.ex
@@ -1,11 +1,11 @@
 defmodule Ueberauth.Strategy.Amco.Exceptions.EmptyErrorHandler do
-  defexception message: "error_handler option is required"
+  defexception message: "Plug option 'error_handler' is required"
 end
 
 defmodule Ueberauth.Strategy.Amco.Exceptions.EmptyAccessTokenSource do
-  defexception message: "access_token_source option is required"
+  defexception message: "Plug option 'access_token_source' is required"
 end
 
 defmodule Ueberauth.Strategy.Amco.Exceptions.MissingSiteConfiguration do
-  defexception message: "site configuration option is missed"
+  defexception message: "Configuration option 'site' is missed"
 end

--- a/lib/ueberauth/strategy/amco/oauth.ex
+++ b/lib/ueberauth/strategy/amco/oauth.ex
@@ -10,7 +10,6 @@ defmodule Ueberauth.Strategy.Amco.OAuth do
 
   @defaults [
     strategy: __MODULE__,
-    site: "https://idp.amco.me",
     token_url: "/oauth2/token",
     authorize_url: "/oauth2/authorize"
   ]

--- a/lib/ueberauth/strategy/amco/oauth.ex
+++ b/lib/ueberauth/strategy/amco/oauth.ex
@@ -8,6 +8,8 @@ defmodule Ueberauth.Strategy.Amco.OAuth do
   """
   use OAuth2.Strategy
 
+  alias Ueberauth.Strategy.Amco.Exceptions
+
   @defaults [
     strategy: __MODULE__,
     token_url: "/oauth2/token",
@@ -31,6 +33,10 @@ defmodule Ueberauth.Strategy.Amco.OAuth do
       |> Keyword.merge(opts)
 
     json_library = Ueberauth.json_library()
+
+    unless Keyword.has_key?(opts, :site) do
+      raise Exceptions.MissingSiteConfiguration
+    end
 
     opts
     |> OAuth2.Client.new()

--- a/test/ueberauth/strategy/amco/oauth_test.exs
+++ b/test/ueberauth/strategy/amco/oauth_test.exs
@@ -1,0 +1,21 @@
+
+defmodule Ueberauth.Strategy.Amco.OAuthTest do
+  use ExUnit.Case
+
+  alias Ueberauth.Strategy.Amco.OAuth
+  alias Ueberauth.Strategy.Amco.Exceptions.MissingSiteConfiguration
+
+  describe "client/1" do
+    test "raises error when site config is missing" do
+      assert_raise MissingSiteConfiguration, fn ->
+        OAuth.client([])
+      end
+    end
+
+    test "does not raise error when site config is present" do
+      site = "https://myidp.example.com"
+      client = OAuth.client(site: site)
+      assert client.site == site
+    end
+  end
+end

--- a/test/ueberauth/strategy/amco/oauth_test.exs
+++ b/test/ueberauth/strategy/amco/oauth_test.exs
@@ -6,16 +6,14 @@ defmodule Ueberauth.Strategy.Amco.OAuthTest do
   alias Ueberauth.Strategy.Amco.Exceptions.MissingSiteConfiguration
 
   describe "client/1" do
-    test "raises error when site config is missing" do
+    test "raises error when missing site configuration" do
       assert_raise MissingSiteConfiguration, fn ->
         OAuth.client([])
       end
     end
 
     test "does not raise error when site config is present" do
-      site = "https://myidp.example.com"
-      client = OAuth.client(site: site)
-      assert client.site == site
+      assert OAuth.client(site: "https://myidp.example.com")
     end
   end
 end


### PR DESCRIPTION
## Addresses issue: [#IDP-44](https://amcoit.atlassian.net/browse/IDP-44)

Remove IdP url from oauth defaults to avoid exposing it to some github scripting. The IdP url can be assigned using phoenix configuration in every app that is using this dep.